### PR TITLE
fix: 🐛 "Last Month's Favorites" title and John Lennon removed

### DIFF
--- a/app/index.md
+++ b/app/index.md
@@ -4,15 +4,11 @@ Welcome to _Onlyrics_, the only place on the planet where your ears won't be dis
 
 
 
-## Picks of the Month
+## Last Month's Favorites
 
 ### [Arctic Monkeys](/writer/arctic_monkeys.md) | arctic.monkeys@onlyrics.magazine
 
 [Fluorescent Adolescent](song/jan/fluorescent_adolescent.md)
-
-### [Jhon Lennon](writer/john_lennon.md) | jhon.lennon@onlyrics.magazine
-
-[Imagine](song/jan/vanilla-panna-cotta.md)
 
 ### [Queen](writer/queen.md) | queen@onlyrics.magazine
 


### PR DESCRIPTION
- Create a section in /app/index.md titled "Last Month's Favorites" without John Lennon